### PR TITLE
Fix command syntax for generating curve certificates

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -9,7 +9,7 @@
 
     ```shell
     just certs
-    just gen-curve
+    just gen_curve
     ```
 - If you intend to public face Bridge, properly obtain certificates from a trusted authority
 


### PR DESCRIPTION
Incorrect:
```
just gen-curve
```

Corrected:
```
just gen_curve
```